### PR TITLE
Use a full path for the Dockerfile entrypoints

### DIFF
--- a/control/Dockerfile
+++ b/control/Dockerfile
@@ -18,5 +18,5 @@ COPY src ./src
 RUN cargo build --target wasm32-wasi --release
 
 FROM scratch
-ENTRYPOINT [ "control.wasm" ]
+ENTRYPOINT [ "/control.wasm" ]
 COPY --link --from=build /src/target/wasm32-wasi/release/control.wasm /control.wasm

--- a/function/Dockerfile
+++ b/function/Dockerfile
@@ -18,5 +18,5 @@ COPY src ./src
 RUN cargo build --target wasm32-wasi --release
 
 FROM scratch
-ENTRYPOINT [ "function.wasm" ]
+ENTRYPOINT [ "/function.wasm" ]
 COPY --link --from=build /src/target/wasm32-wasi/release/function.wasm /function.wasm

--- a/hello/Dockerfile
+++ b/hello/Dockerfile
@@ -18,5 +18,5 @@ COPY src ./src
 RUN cargo build --target wasm32-wasi --release
 
 FROM scratch
-ENTRYPOINT [ "hello.wasm" ]
+ENTRYPOINT [ "/hello.wasm" ]
 COPY --link --from=build /src/target/wasm32-wasi/release/hello.wasm /hello.wasm

--- a/move/Dockerfile
+++ b/move/Dockerfile
@@ -18,5 +18,5 @@ COPY src ./src
 RUN cargo build --target wasm32-wasi --release
 
 FROM scratch
-ENTRYPOINT [ "move.wasm" ]
+ENTRYPOINT [ "/move.wasm" ]
 COPY --link --from=build /src/target/wasm32-wasi/release/move.wasm /move.wasm

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -18,5 +18,5 @@ COPY src ./src
 RUN cargo build --target wasm32-wasi --release
 
 FROM scratch
-ENTRYPOINT [ "server.wasm" ]
+ENTRYPOINT [ "/server.wasm" ]
 COPY --link --from=build /src/target/wasm32-wasi/release/server.wasm /server.wasm

--- a/string/Dockerfile
+++ b/string/Dockerfile
@@ -18,5 +18,5 @@ COPY src ./src
 RUN cargo build --target wasm32-wasi --release
 
 FROM scratch
-ENTRYPOINT [ "string.wasm" ]
+ENTRYPOINT [ "/string.wasm" ]
 COPY --link --from=build /src/target/wasm32-wasi/release/string.wasm /string.wasm

--- a/struct/Dockerfile
+++ b/struct/Dockerfile
@@ -18,5 +18,5 @@ COPY src ./src
 RUN cargo build --target wasm32-wasi --release
 
 FROM scratch
-ENTRYPOINT [ "struct.wasm" ]
+ENTRYPOINT [ "/struct.wasm" ]
 COPY --link --from=build /src/target/wasm32-wasi/release/struct.wasm /struct.wasm

--- a/wasi/Dockerfile
+++ b/wasi/Dockerfile
@@ -18,5 +18,5 @@ COPY src ./src
 RUN cargo build --target wasm32-wasi --release
 
 FROM scratch
-ENTRYPOINT [ "wasi.wasm" ]
+ENTRYPOINT [ "/wasi.wasm" ]
 COPY --link --from=build /src/target/wasm32-wasi/release/wasi.wasm /wasi.wasm


### PR DESCRIPTION
The Dockerfiles are currently using the name of the wasm file as the entrypoint for the containers.

With the move of `containerd-shim-wasmedge-v1` to `youki`, the entrypoint is now resolved using `PATH` (same as for normal linux containers). See https://github.com/containerd/runwasi/issues/143

This PR fixes that issue.