### PR TITLE
docs: update wasm target from wasm32-wasi to wasm32-wasip1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,26 +21,26 @@ jobs:
 
       - name: Install Rust target for wasm
         run: |
-          rustup target add wasm32-wasi
+          rustup target add wasm32-wasip1
 
       - name: Build Wasm files
         run: |
           cd control
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
           cd ../function
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
           cd ../hello
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
           cd ../move
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
           cd ../server
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
           cd ../string
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
           cd ../struct
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
           cd ../wasi
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
 
       - name: Create Release
         id: create_release
@@ -56,7 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          file: "*/target/wasm32-wasi/release/*.wasm"
+          file: "*/target/wasm32-wasip1/release/*.wasm"
           release_id: ${{ steps.create_release.outputs.id }}
           overwrite: true
           verbose: true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Or, you could install [Rust](https://www.rust-lang.org/tools/install) and [WasmE
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 
 curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | sudo bash -s -- -p /usr/local
 ```

--- a/hello/README.md
+++ b/hello/README.md
@@ -15,13 +15,13 @@ The [`src/main.rs`](src/main.rs) source code shows
 Compile the Rust source code project to a Wasm bytecode file.
 
 ```
-$ cargo build --target wasm32-wasi --release
+$ cargo build --target wasm32-wasip1 --release
 ```
 
 Run the Wasm bytecode file in WasmEdge CLI.
 
 ```
-$ wasmedge target/wasm32-wasi/release/hello.wasm
+$ wasmedge target/wasm32-wasip1/release/hello.wasm
 Hello WasmEdge!
 ```
 


### PR DESCRIPTION
Hi team, 

I found some outdated targets in the getting started examples; here is the fix. Many thanks!